### PR TITLE
allow for the default credentials provider chain to be wired in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.1
-      env: SYMFONY_VERSION=4.0.*
-    - php: 7.1
       env: SYMFONY_VERSION=4.1.*
     - php: 7.2
       env: SYMFONY_VERSION=4.1.*

--- a/src/DependencyInjection/AwsSecretsExtension.php
+++ b/src/DependencyInjection/AwsSecretsExtension.php
@@ -39,6 +39,10 @@ class AwsSecretsExtension extends Extension
         $container->setParameter('aws_secrets.ignore', $configs['ignore']);
         $container->setParameter('aws_secrets.delimiter', $configs['delimiter']);
 
+        if ($configs['default_credentials_provider_chain_enabled']) {
+            unset($configs['client_config']['credentials']);
+        }
+
         $container->register('aws_secrets.secrets_manager_client', SecretsManagerClient::class)
             ->setLazy(true)
             ->addArgument($configs['client_config'])

--- a/src/DependencyInjection/AwsSecretsExtension.php
+++ b/src/DependencyInjection/AwsSecretsExtension.php
@@ -4,10 +4,10 @@ namespace AwsSecretsBundle\DependencyInjection;
 
 use Aws\SecretsManager\SecretsManagerClient;
 use AwsSecretsBundle\AwsSecretsEnvVarProcessor;
-use AwsSecretsBundle\Command\AwsSecretValueCommand;
 use AwsSecretsBundle\Provider\AwsSecretsArrayEnvVarProvider;
 use AwsSecretsBundle\Provider\AwsSecretsCachedEnvVarProvider;
 use AwsSecretsBundle\Provider\AwsSecretsEnvVarProvider;
+use Exception;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,6 +29,7 @@ class AwsSecretsExtension extends Extension
      *
      * @param array $configs
      * @param ContainerBuilder $container
+     * @throws Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -39,7 +40,16 @@ class AwsSecretsExtension extends Extension
         $container->setParameter('aws_secrets.ignore', $configs['ignore']);
         $container->setParameter('aws_secrets.delimiter', $configs['delimiter']);
 
-        if ($configs['default_credentials_provider_chain_enabled']) {
+        $credentials = $configs['client_config']['credentials'];
+        if ($credentials['key'] !== null || $credentials['secret'] !== null) {
+            if ($credentials['key'] === null || $credentials['secret'] === null) {
+                throw new Exception('Both key and secret must be provided or neither');
+            }
+        } else {
+            unset($configs['client_config']['credentials']);
+        }
+
+        if (!$configs['client_config']['credentials']['key'] || !$configs['client_config']['credentials']['secret']) {
             unset($configs['client_config']['credentials']);
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,7 +41,6 @@ class Configuration implements ConfigurationInterface
             ->enumNode('cache')->values(['apcu', 'filesystem', 'array'])->defaultValue('array')->end()
             ->scalarNode('ttl')->defaultValue(60)->end()
             ->scalarNode('delimiter')->defaultValue(',')->end()
-            ->scalarNode('default_credentials_provider_chain_enabled')->defaultFalse()->end()
             ->scalarNode('ignore')->defaultFalse()->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
             ->enumNode('cache')->values(['apcu', 'filesystem', 'array'])->defaultValue('array')->end()
             ->scalarNode('ttl')->defaultValue(60)->end()
             ->scalarNode('delimiter')->defaultValue(',')->end()
+            ->scalarNode('default_credentials_provider_chain_enabled')->defaultFalse()->end()
             ->scalarNode('ignore')->defaultFalse()->end();
 
         return $treeBuilder;


### PR DESCRIPTION
If not using a pre-existing access/secret key, allow for the default credential provider chain to be used.